### PR TITLE
feat(ci-workflow): add gatsby publish gh action, remove Travis

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: actions/checkout@v1
       - uses: enriikke/gatsby-gh-pages-action@v2.2.0
         with:
-          access-token: ${{ secrets.DEV_DOCS_TOKEN }}
+          access-token: ${{ secrets.DEV_DOCS_FORK_TOKEN }}
           deploy-brach: gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,15 @@
+name: Publish Developer Docs Site
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: enriikke/gatsby-gh-pages-action@v2.2.0
+        with:
+          access-token: ${{ secrets.DEV_DOCS_TOKEN }}
+          deploy-brach: gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - "10"
-deploy:
-  provider: script
-  script: npm install && npm run deploy_from_ci
-  skip_cleanup: true
-  on:
-    branch: master

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To collaborate with this repository in GitHub you need to follow these steps:
 - Push the changes to your repository
 - Create a Pull Request from your repository back to the original one
 
-Then the codeowners will review your Pull Request and if the PR is accepted and merged into master Travis CI will deploy the new version of the site.
+Then the codeowners will review your Pull Request and if the PR is accepted and merged into master a Github Action will build and push the site to the `gh-pages` branch and the deployment is done. 
 
 ## How To
 
@@ -61,20 +61,7 @@ in order to create a new page, you have to
 
 ## Deployment
 
-The build and deployment process is automated with Travis CI and triggered by pushing to the master branch.
-
-You can check the deployment logs here: https://travis-ci.org/github/IBM/video-streaming-developer-docs
-
-For a change, please create a branch, and make a pull request to master.
-On every merge to master, deployment will start automatically, triggered by Travis.
-After 5-10 minutes, the changes will takes effect on the developer site live environment
-https://developers.video.ibm.com/
-
-### Additional details about build and deployment
-
-Travis runs `gatsby build --prefix-paths`, which generates the production code in the /public directory.  
-Then gh-pages node command will copy the `/public` directory's content into gh-pages branch.
-The github pages url serves the content of the gh-pages branch.
+The project uses this Github Action to build and publish the site: [Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish)
 
 ### Tips
 


### PR DESCRIPTION
## Overview

- __Type:__
  - 🛠Build
  - ♻️Chore
  - 📚Docs
  - 📦Refactor
  - 🚢Release
- __Ticket:__ No

With this change we move the CI/CD workflow from Travis CI to  Github Actions with this action: [Gatsby Publish](https://github.com/marketplace/actions/gatsby-publish)